### PR TITLE
Add consult-notmuch to notmuch layer for vertico

### DIFF
--- a/layers/+email/notmuch/packages.el
+++ b/layers/+email/notmuch/packages.el
@@ -25,6 +25,7 @@
   '(
     (counsel-notmuch :requires ivy)
     (helm-notmuch :requires helm)
+    (consult-notmuch :requires consult)
     notmuch
     org
     persp-mode
@@ -40,6 +41,11 @@
   (use-package helm-notmuch
     :defer t
     :init (spacemacs/set-leader-keys "aenn" 'helm-notmuch)))
+
+(defun notmuch/init-consult-notmuch ()
+  (use-package helm-notmuch
+    :defer t
+    :init (spacemacs/set-leader-keys "aenn" 'consult-notmuch)))
 
 (defun notmuch/init-ol-notmuch ()
   (use-package ol-notmuch)


### PR DESCRIPTION
This pull request adds [https://codeberg.org/jao/consult-notmuch](https://github.com/syl20bnr/spacemacs/pull/consult-notmuch) to notmuch layer for compleseus completion engine.