### PR TITLE
Update configuration and key bindings for GPTel layer

### DIFF
--- a/layers/+web-services/llm-client/README.org
+++ b/layers/+web-services/llm-client/README.org
@@ -6,6 +6,8 @@
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
+- [[#configuration][Configuration]]
+- [[#key-bindings][Key bindings]]
 
 * Description
 This layer enables usage of GPT Clients in Spacemacs using [[https://github.com/karthink/gptel][GPTel]].
@@ -31,3 +33,30 @@ You will have access to the following tools:
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =llm-client= to the existing =dotspacemacs-configuration-layers= list in this
 file.
+
+* Configuration
+Refer to the official [[https://github.com/karthink/gptel][GPTel]] documentation for advanced configurations and
+additional information.
+
+* Key bindings
+The layer provides several key bindings to interact with LLMs efficiently. Here
+are some of the key bindings available:
+
+| Key binding | Command                  | Description                |
+|-------------+--------------------------+----------------------------|
+| ~SPC $ g g~   | gptel                    | Start a new GPTel session  |
+| ~SPC $ g s~   | gptel-send               | Send a message to GPTel    |
+| ~SPC $ g m~   | gptel-menu               | Open the GPTel menu        |
+| ~SPC $ g c~   | gptel-context-add        | Add context                |
+| ~SPC $ g f~   | gptel-add-file           | Add a file                 |
+| ~SPC $ g o~   | gptel-org-set-topic      | Set topic in Org-mode      |
+| ~SPC $ g p~   | gptel-org-set-properties | Set properties in Org-mode |
+
+
+In addition, this layer adds the following keybindings to =org-mode=
+
+
+| Key binding   | Command                  | Description                |
+|---------------+--------------------------+----------------------------|
+| ~SPC m $ g o~ | gptel-org-set-topic      | Set topic in Org-mode      |
+| ~SPC m $ g p~   | gptel-org-set-properties | Set properties in Org-mode |

--- a/layers/+web-services/llm-client/packages.el
+++ b/layers/+web-services/llm-client/packages.el
@@ -3,6 +3,7 @@
 ;; Copyright (c) 2012-2024 Sylvain Benner & Contributors
 ;;
 ;; Author: Codruț Constantin Gușoi <mail+spacemacs@codrut.pro>
+;; Author: Alexander Matyasko <alexander.matyasko@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
@@ -22,8 +23,45 @@
 
 
 (defconst llm-client-packages
-  '(gptel))
+  '(gptel
+    org
+    window-purpose))
 
 (defun llm-client/init-gptel ()
+  "Initialize the `gptel` package and set up keybindings."
   (use-package gptel
-    :defer t))
+    :defer t
+    :ensure t
+    :config
+    (spacemacs/declare-prefix "$g" "Gptel")
+    (spacemacs/set-leader-keys
+      "$gg" 'gptel              ; Start a new GPTel session
+      "$gs" 'gptel-send         ; Send a message to GPTel
+      "$gm" 'gptel-menu         ; Open the GPTel menu
+      "$gc" 'gptel-context-add  ; Add context
+      "$gf" 'gptel-add-file     ; Add a file
+      "$go" 'gptel-org-set-topic ; Set topic in Org-mode
+      "$gp" 'gptel-org-set-properties))) ; Set properties in Org-mode
+
+(defun llm-client/post-init-org ()
+  "Set up Org-mode keybindings for GPTel."
+  (spacemacs/declare-prefix "m$g" "Gptel")
+  (spacemacs/set-leader-keys-for-major-mode 'org-mode
+    "$go" 'gptel-org-set-topic
+    "$gp" 'gptel-org-set-properties))
+
+(defun llm-client/post-init-window-purpose ()
+  ;; TODO: Temporary fix to avoid the error when using window-purpose
+  ;; see https://github.com/karthink/gptel/issues/237 for details
+  ;; (purpose-set-extension-configuration
+  ;;  :llm-client-layer
+  ;;  (purpose-conf :mode-purposes '((gptel-mode . chat))))
+  (defun llm-client/disable-purpose-mode-around-for-gptel (orig-func &rest args)
+    "Advice function to disable purpose-mode before calling ORIG-FUNC with ARGS."
+    (let ((purpose-mode-was-enabled (bound-and-true-p purpose-mode)))
+      (when purpose-mode-was-enabled
+        (purpose-mode -1))
+      (apply orig-func args)
+      (when purpose-mode-was-enabled
+        (purpose-mode 1))))
+  (advice-add 'gptel :around #'llm-client/disable-purpose-mode-around-for-gptel))


### PR DESCRIPTION
- Added additional key bindings for GPTel package;
- Updated README.org to include documentation about the additional key bindings;
- Added post-init function for org to set up org-mode specific key bindings;
- Implemented a workaround in the window-purpose post-init to prevent errors when using the gptel function by temporarily disabling window-purpose.